### PR TITLE
Fix 500 on missing GitHub resources and broken URLs from new webhook format

### DIFF
--- a/GitHub.cs
+++ b/GitHub.cs
@@ -170,8 +170,8 @@ namespace Saucery
             // Defensive: old rows may have been stored either with or without "/repos/" depending on the
             // webhook payload format at the time. Strip then re-add so the result is always exactly one "/repos/".
             repositoryUrl = repositoryUrl
-                .Replace("https://api.github.com/repos/", "https://api.github.com/")
-                .Replace("https://api.github.com", "https://api.github.com/repos");
+                .ReplaceIgnoreCase("https://api.github.com/repos/", "https://api.github.com/")
+                .ReplaceIgnoreCase("https://api.github.com", "https://api.github.com/repos");
 
             try
             {
@@ -241,8 +241,8 @@ namespace Saucery
             // Convert the stored API URL back to the human-facing GitHub URL. Strip "/repos/" defensively
             // so old rows stored as https://api.github.com/repos/owner/repo render as https://github.com/owner/repo.
             var humanRepositoryUrl = repositoryURL
-                .Replace("api.github.com/repos/", "github.com/")
-                .Replace("api.github.com", "github.com");
+                .ReplaceIgnoreCase("api.github.com/repos/", "github.com/")
+                .ReplaceIgnoreCase("api.github.com", "github.com");
 
             form.Append(string.Format("<div class='hardBreak'><a href='{0}'>{0}<a></div>", humanRepositoryUrl));
             

--- a/GitHub.cs
+++ b/GitHub.cs
@@ -167,7 +167,11 @@ namespace Saucery
 
             RestSharp.IRestResponse response;
             
-            repositoryUrl = repositoryUrl.Replace("https://api.github.com","https://api.github.com/repos");
+            // Defensive: old rows may have been stored either with or without "/repos/" depending on the
+            // webhook payload format at the time. Strip then re-add so the result is always exactly one "/repos/".
+            repositoryUrl = repositoryUrl
+                .Replace("https://api.github.com/repos/", "https://api.github.com/")
+                .Replace("https://api.github.com", "https://api.github.com/repos");
 
             try
             {
@@ -210,9 +214,11 @@ namespace Saucery
             }
             else if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
-                GeminiApp.LogException(new FileNotFoundException(response.Content) { Source = SourceControlProvider.SVN.ToString() }, false);
-                
-                throw new FileNotFoundException(response.Content);
+                var notFoundMessage = string.Format("GitHub returned 404 for URL: {0} - Response: {1}", url, response.Content);
+
+                GeminiApp.LogException(new FileNotFoundException(notFoundMessage) { Source = SourceControlProvider.GitHub.ToString() }, false);
+
+                throw new FileNotFoundException(notFoundMessage);
             }
             else if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
             {
@@ -232,7 +238,13 @@ namespace Saucery
         {
             StringBuilder form = new StringBuilder();
             
-            form.Append(string.Format("<div class='hardBreak'><a href='{0}'>{0}<a></div>", repositoryURL.Replace("api.github.com","github.com")));
+            // Convert the stored API URL back to the human-facing GitHub URL. Strip "/repos/" defensively
+            // so old rows stored as https://api.github.com/repos/owner/repo render as https://github.com/owner/repo.
+            var humanRepositoryUrl = repositoryURL
+                .Replace("api.github.com/repos/", "github.com/")
+                .Replace("api.github.com", "github.com");
+
+            form.Append(string.Format("<div class='hardBreak'><a href='{0}'>{0}<a></div>", humanRepositoryUrl));
             
             form.Append(string.Format("<form id='authentication_form' action='apps/saucery/authenticate/{0}' method='post'>", SourceControlProvider.GitHub));
             
@@ -375,11 +387,17 @@ namespace Saucery
                         // If there are empty fielid's go and get them
                         if (emptyFileIds.Count() > 0)
                         {
-                            var githubCommit = GetResponse(string.Concat(data.RepositoryUrl.ReplaceIgnoreCase("https://api.github.com", "https://api.github.com/repos"), "/git/commits/", revisionId), RestSharp.Method.GET);
-                            
+                            // Defensive: old rows may have been stored either with or without "/repos/" depending on the
+                            // webhook payload format at the time. Strip then re-add so the result always has exactly one "/repos/".
+                            var apiBaseUrl = data.RepositoryUrl
+                                .ReplaceIgnoreCase("https://api.github.com/repos/", "https://api.github.com/")
+                                .ReplaceIgnoreCase("https://api.github.com", "https://api.github.com/repos");
+
+                            var githubCommit = GetResponse(string.Concat(apiBaseUrl, "/git/commits/", revisionId), RestSharp.Method.GET);
+
                             var githubCommitJson = githubCommit.Content.FromJson<TreeUrl>();
 
-                            var githubPreviousCommit = GetResponse(string.Concat(data.RepositoryUrl.ReplaceIgnoreCase("https://api.github.com", "https://api.github.com/repos"), "/git/commits/", githubCommitJson.parents.First().sha), RestSharp.Method.GET);
+                            var githubPreviousCommit = GetResponse(string.Concat(apiBaseUrl, "/git/commits/", githubCommitJson.parents.First().sha), RestSharp.Method.GET);
                             
                             var githubPreviousCommitJson = githubPreviousCommit.Content.FromJson<TreeUrl>();
 
@@ -510,7 +528,12 @@ namespace Saucery
                 if (matches.Count > 0)
                 {
 
-                    var baseUrl = commits.repository.url.ReplaceIgnoreCase("https://github.com/", "https://api.github.com/");
+                    // GitHub's webhook payload now puts the API URL (https://api.github.com/repos/owner/repo) in repository.url
+                    // rather than the html URL (https://github.com/owner/repo). Normalize both shapes to the canonical
+                    // https://api.github.com/owner/repo form so the call sites that prepend "/repos" still work.
+                    var baseUrl = commits.repository.url
+                        .ReplaceIgnoreCase("https://github.com/", "https://api.github.com/")
+                        .ReplaceIgnoreCase("https://api.github.com/repos/", "https://api.github.com/");
 
                     List<string> filesModified = new List<string>();
 

--- a/Saucery.cs
+++ b/Saucery.cs
@@ -26,6 +26,7 @@ using Countersoft.Gemini;
 using System.Net;
 using System.Net.Security;
 using System.Web.UI;
+using System.IO;
 
 namespace Saucery
 {
@@ -299,7 +300,11 @@ namespace Saucery
 
                     if (commit.Provider == SourceControlProvider.GitHub)
                     {
-                        dataHolder.commits.ExtraData = dataHolder.commits.RepositoryUrl.ReplaceIgnoreCase("https://api.github.com", "https://github.com");
+                        // Convert the stored API URL back to the human-facing GitHub URL. Strip "/repos/" defensively
+                        // so old rows stored as https://api.github.com/repos/owner/repo render as https://github.com/owner/repo.
+                        dataHolder.commits.ExtraData = dataHolder.commits.RepositoryUrl
+                            .ReplaceIgnoreCase("https://api.github.com/repos/", "https://github.com/")
+                            .ReplaceIgnoreCase("https://api.github.com", "https://github.com");
                     }
 
                     dataHolder.Provider = commit.Provider;
@@ -425,14 +430,26 @@ namespace Saucery
                         catch (UnauthorizedAccessException ex)
                         {
                             authenticateForm = github.CreateAuthenticationForm(UserContext.Url, repositoryUrl, fileName);
-                            
+
                             errorMessage = "Invalid login details";
+                        }
+                        catch (FileNotFoundException ex)
+                        {
+                            GeminiApp.LogException(ex, false);
+
+                            errorMessage = "Unable to load diff: the commit, file, or repository could not be found on GitHub. It may have been removed, renamed, force-pushed, or you may no longer have access to it.";
+                        }
+                        catch (Exception ex)
+                        {
+                            GeminiApp.LogException(ex, false);
+
+                            errorMessage = "Unable to load diff from GitHub. See server logs for details.";
                         }
                     }
                     else
                     {
                         authenticateForm = github.CreateAuthenticationForm(UserContext.Url, repositoryUrl, fileName);
-                        
+
                         errorMessage = "Invalid login details";
                     }
 


### PR DESCRIPTION
## Summary

`GetFileDiff` was returning HTTP 500 when GitHub responded 404 to any of the calls in `updateFileIds`, because `GitHub.GetResponse` converts a 404 into a `FileNotFoundException` and the controller only caught `UnauthorizedAccessException`. The 404 itself was caused by the GitHub webhook payload now putting the API URL (`https://api.github.com/repos/owner/repo`) in `repository.url` rather than the html URL (`https://github.com/owner/repo`), so the call sites that prepend `/repos` were producing a double `/repos/repos/` path.

## What changed

**Error handling**
- `GitHub.GetResponse`: include the failing URL in the `FileNotFoundException` so the next 404 in the logs identifies which call failed; also fix the `Source` from `SVN` (copy-paste bug) to `GitHub`.
- `SauceryController.GetFileDiff`: catch `FileNotFoundException` and a fallback `Exception` in the GitHub branch, log them, and surface a friendly `errorMessage` via the existing `JsonSuccess` + `gemini_popup.toast` path so the user sees a clear message instead of a 500.

**URL normalization (handles both old and new webhook payload shapes)**
- `GitHub.Commit`: strip `/repos/` from incoming `repository.url` at ingest so newly stored rows are always canonical.
- `GitHub.GetFileContent` and `GitHub.updateFileIds`: defensive strip-then-add `/repos/` so existing rows that already contain `/repos/` no longer produce a double `/repos/repos/` path.
- `GitHub.CreateAuthenticationForm` and `SauceryController.GetCommits` (`ExtraData`): defensive strip `/repos/` when converting the stored API URL back to the human-facing `https://github.com/owner/repo` form so the auth form link and the "Github" view-changeset link render correctly for existing rows.

No data migration is required: new commits ingest cleanly, and old rows are normalized at every read site.

## Test plan

- [ ] Build the solution — confirmed locally with MSBuild (0 errors, only pre-existing CS0168 warnings).
- [ ] Click a file diff for an issue whose stored `RepositoryUrl` contains `/repos/` (the new webhook format) — should render the diff (or, if GitHub really 404s the resource, show a toast instead of a 500).
- [ ] Click the "Github" view-changeset link on a GitHub commit — should resolve to `https://github.com/owner/repo/commit/<sha>` with no extra `/repos/`.
- [ ] Trigger the auth form (e.g. by deleting the stored access token) — the repo link above the form should be `https://github.com/owner/repo` with no extra `/repos/`.
- [ ] Push a new commit with a `GEM:<id>` reference and confirm the resulting `CodeCommit.Data` contains a `RepositoryUrl` of `https://api.github.com/owner/repo` (no `/repos/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)